### PR TITLE
Add 3.5-inch screen check

### DIFF
--- a/RSEnvironment/RSEnvironment.h
+++ b/RSEnvironment/RSEnvironment.h
@@ -113,6 +113,9 @@ extern RSEKit *RSEnvironment;
 /// Resolution of the screen in pixels;
 @property (nonatomic, readonly) CGSize resolution;
 
+/// Detects if the screen has iPhone 4/4S size
+@property (nonatomic, readonly) BOOL is3_5InchSize;
+
 /// Detects if the screen has iPhone 5/5S/5C size
 @property (nonatomic, readonly) BOOL is4InchSize;
 

--- a/RSEnvironment/RSEnvironment.m
+++ b/RSEnvironment/RSEnvironment.m
@@ -173,7 +173,7 @@ RSEKit *RSEnvironment;
 
 @end
 
-#pragma mark └ .version
+#pragma mark - .version
 @implementation RSEVersion
 
 +(instancetype)versionWithString:(NSString *)version{
@@ -330,6 +330,10 @@ RSEKit *RSEnvironment;
     CGSize size = self.size;
     CGFloat scale = self.scale;
     return CGSizeMake(size.width * scale, size.height * scale);
+}
+
+-(BOOL)is3_5InchSize{
+    return RSEnvironment.UI.isIdiomIPhone && self.size.height == 480.f;
 }
 
 -(BOOL)is4InchSize{


### PR DESCRIPTION
Hello, @rabovik !!

To leverage RSEnvironment in my application entirely I need this 3.5-inch check as we support iPhone 4, 4S devices.

Your modularized Facade implementation of these environment checks is the best I've ever seen on Github so well it is engineered. During New Year 2015 holidays I was going to implement 95% similar project but it was great to find that you had it already done so that I have nothing to add. 

Excellent work!

Thanks.


